### PR TITLE
fix: bug encountered when going to Orders(order history) in main nav when not loggedIn or registered

### DIFF
--- a/frontend/src/context/RequireAuth.tsx
+++ b/frontend/src/context/RequireAuth.tsx
@@ -11,7 +11,7 @@ const RequireAuth = () => {
    auth?.accessToken ? (
       <Outlet />
     ) : (
-      <Navigate to="/sign-up" state={{ from: location.pathname , pizza: location.state.pizza }} replace />
+      <Navigate to="/sign-up" state={{ from: location?.pathname , pizza: location?.state?.pizza }} replace />
     )
   );
 };

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  AlertColor,
   Box,
   Checkbox,
   Divider,
@@ -21,7 +22,7 @@ import LocationOnIcon from "@mui/icons-material/LocationOn";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import navbar_logo from "../assets/navbar_logo.svg";
 import pizza_slice from "../assets/pizza_slice.svg";
@@ -38,6 +39,7 @@ import { AbilityContext } from "@/context/AbilityProvider";
 function Register() {
   const [open, setOpen] = useState(false);
   const [errMsg, setErrMsg] = useState("");
+  const [severity, setSeverity] = useState<AlertColor | undefined>();
   const [showPassword, setShowPassword] = useState(false);
   const { setAuth } = useAuth();
 
@@ -48,6 +50,14 @@ function Register() {
   const from = location?.state?.from;
   const pizza = location?.state?.pizza;
 
+  useEffect(() => {
+    if(from === "/order_history") {
+      setSeverity("info")
+      setErrMsg("Please Register or Login to continue Viewing Your Order History!")
+      setOpen(true);
+    }
+  }, [from])
+  
   const {
     handleSubmit,
     formState: { isSubmitting, errors },
@@ -96,6 +106,7 @@ function Register() {
       console.log(response);
     } catch (err: any) {
       console.error(err);
+      setSeverity("error")
       if (!err?.response) {
         setErrMsg("Server can not be reached, Please Try again later!");
       } else if (err.response?.status === 400) {
@@ -127,7 +138,7 @@ function Register() {
             horizontal: "center",
           }}
         >
-          <Alert severity="error" variant="filled" onClose={handleClose}>
+          <Alert severity={severity} variant="filled" onClose={handleClose}>
             {errMsg}
           </Alert>
         </Snackbar>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5174,
+    // port: 5174,
   },
   // This helps for using @ alias for import statements
   resolve: {


### PR DESCRIPTION
If a user is not logged in or registered and tries to go to orders(order history) which is in main nav, we get the bellow error
```
Unexpected Application Error!
Cannot read properties of null (reading 'pizza')
TypeError: Cannot read properties of null (reading 'pizza')
    at nP (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:292:125655)
    at L1 (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:38:17018)
    at jM (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:44058)
    at PM (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:39790)
    at oA (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:39718)
    at Um (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:39570)
    at Hx (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:35934)
    at SM (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:40:34883)
    at k (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:25:1542)
    at MessagePort.E (https://pizza-ordering-service-nine.vercel.app/assets/index-CwkhWDyd.js:25:1904)
```
fixed it, By making the pizza optional in RequireAuth.tsx and providing a toast message accordingly for the user